### PR TITLE
Update NodeJS to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     default: 'v'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Just patching to use NodeJS v20 than v18 to deal with GitHub Warning